### PR TITLE
Bump go-rancher-metadata

### DIFF
--- a/trash.conf
+++ b/trash.conf
@@ -42,5 +42,5 @@ google.golang.org/appengine	267c27e
 google.golang.org/cloud	4f1a5ca
 gopkg.in/inf.v0	v0.9.0
 k8s.io/kubernetes	v1.3.0
-github.com/rancher/go-rancher-metadata 35e03f14760339cb8fb83e21ba4a21b4e9e1d201
+github.com/rancher/go-rancher-metadata c48cdb6a5f2b96797f4163f47ceb5fa387ab71c4
 github.com/pkg/errors 1d2e60385a13aaa66134984235061c2f9302520e

--- a/vendor/github.com/rancher/go-rancher-metadata/metadata/change.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/metadata/change.go
@@ -1,6 +1,8 @@
 package metadata
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -11,17 +13,25 @@ func (m *client) OnChange(intervalSeconds int, do func(string)) {
 	version := "init"
 
 	for {
-		newVersion, err := m.GetVersion()
+		newVersion, err := m.waitVersion(intervalSeconds, version)
 		if err != nil {
 			logrus.Errorf("Error reading metadata version: %v", err)
 			time.Sleep(interval * time.Second)
 		} else if version == newVersion {
 			logrus.Debug("No changes in metadata version")
-			time.Sleep(interval * time.Second)
 		} else {
 			logrus.Debugf("Metadata Version has been changed. Old version: %s. New version: %s.", version, newVersion)
 			version = newVersion
 			do(newVersion)
 		}
 	}
+}
+
+func (m *client) waitVersion(maxWait int, version string) (string, error) {
+	resp, err := m.SendRequest(fmt.Sprintf("/version?wait=true&value=%s&maxWait=%d", version, maxWait))
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(resp, &version)
+	return version, err
 }

--- a/vendor/github.com/rancher/go-rancher-metadata/metadata/metadata.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/metadata/metadata.go
@@ -22,6 +22,7 @@ type Client interface {
 	GetServiceContainers(string, string) ([]Container, error)
 	GetHosts() ([]Host, error)
 	GetHost(string) (Host, error)
+	GetNetworks() ([]Network, error)
 }
 
 type client struct {
@@ -238,4 +239,18 @@ func (m *client) GetHost(UUID string) (Host, error) {
 	}
 
 	return host, fmt.Errorf("could not find host by UUID %v", UUID)
+}
+
+func (m *client) GetNetworks() ([]Network, error) {
+	resp, err := m.SendRequest("/networks")
+	var networks []Network
+	if err != nil {
+		return networks, err
+	}
+
+	if err = json.Unmarshal(resp, &networks); err != nil {
+		return networks, err
+	}
+
+	return networks, nil
 }

--- a/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
@@ -20,6 +20,7 @@ type Service struct {
 	Scale              int                    `json:"scale"`
 	Name               string                 `json:"name"`
 	StackName          string                 `json:"stack_name"`
+	StackUUID          string                 `json:"stack_uuid"`
 	Kind               string                 `json:"kind"`
 	Hostname           string                 `json:"hostname"`
 	Vip                string                 `json:"vip"`
@@ -61,6 +62,14 @@ type Container struct {
 	DnsSearch                []string          `json:"dns_search"`
 	HealthCheckHosts         []string          `json:"health_check_hosts"`
 	NetworkFromContainerUUID string            `json:"network_from_container_uuid"`
+	NetworkUUID              string            `json:"network_uuid"`
+}
+
+type Network struct {
+	Name      string                 `json:"name"`
+	UUID      string                 `json:"uuid"`
+	Metadata  map[string]interface{} `json:"metadata"`
+	HostPorts bool                   `json:"host_ports"`
 }
 
 type Host struct {


### PR DESCRIPTION
Pull in newer go-rancher-metadata so that OnChange happens on demand and
not based on the interval.