### PR TITLE
Fixed for adding cookie when using a custom stickiness directive

### DIFF
--- a/provider/haproxy/config/haproxy_template.cfg
+++ b/provider/haproxy/config/haproxy_template.cfg
@@ -52,7 +52,7 @@ acl {{$svcName}}_path path_beg -i {{$svc.Path}}
 use_backend {{$svcName}} if {{$svcName}}_host {{$svcName}}_path
 {{else -}}
 use_backend {{$svcName}} if {{$svcName}}_path
-{{end -}} 
+{{end -}}
 {{else if $svc.Host -}}
 use_backend {{$svcName}} if {{$svcName}}_host
 {{else -}}
@@ -82,6 +82,6 @@ mode tcp
 {{else -}}
 mode {{$backend.Protocol}}
 {{end -}}
-{{range $j, $ep := $backend.Endpoints}}server {{$ep.Name}} {{$ep.IP}}:{{$ep.Port}} {{$ep.Config}}
+{{range $j, $ep := $backend.Endpoints}}server {{$ep.Name}} {{$ep.IP}}:{{$ep.Port}} {{ if $ep.Config }}{{$ep.Config}}{{else}} cookie {{ $j }}{{end}}
 {{end -}}
 {{end -}}


### PR DESCRIPTION
We are using custom JSESSIONID from the application containers, however with v1.2.X the prefix mode breaks as the cookie add contains the suffix for backend stack. To work around this we can add the stickiness directive from the free text config which lb-controller can merge.

However in this scenario the cookie directive is getting dropped. The fix adds a counter as cookie id and still allows you to use your own stickiness cookie directive. 

I have tested locally and works fine without breaking anything else. 