### PR TITLE
hostname wildcard bug fix

### DIFF
--- a/controller/rancher/rancher.go
+++ b/controller/rancher/rancher.go
@@ -224,11 +224,11 @@ func (lbc *LoadBalancerController) BuildConfigFromMetadata(lbName string, envUUI
 		}
 
 		if len(hostname) > 2 {
-			if strings.HasPrefix(hostname, "*.") {
-				hostname = hostname[2:len(hostname)]
+			if strings.HasPrefix(hostname, "*") {
+				hostname = hostname[1:len(hostname)]
 				comparator = config.EndRuleComparator
-			} else if strings.HasSuffix(hostname, ".*") {
-				hostname = hostname[:len(hostname)-2]
+			} else if strings.HasSuffix(hostname, "*") {
+				hostname = hostname[:len(hostname)-1]
 				comparator = config.BegRuleComparator
 			}
 		}

--- a/controller/rancher/rancher_test.go
+++ b/controller/rancher/rancher_test.go
@@ -270,7 +270,7 @@ func TestPriority(t *testing.T) {
 	if bes[0].Host != port4.Hostname {
 		t.Fatalf("Invalid order for the 1st element: [%v]", bes[0].UUID)
 	}
-	if bes[1].Host != "bar" {
+	if bes[1].Host != ".bar" {
 		t.Fatalf("Invalid order for the 2nd element: [%v]", bes[1].UUID)
 	}
 	if bes[2].Host != port0.Hostname {
@@ -317,7 +317,7 @@ func TestPriorityExtra(t *testing.T) {
 		t.Fatalf("Invalid backend length [%v]", len(bes))
 	}
 
-	if bes[0].Host != "fooff" {
+	if bes[0].Host != ".fooff" {
 		t.Fatalf("Invalid order for the 1st element: [%v]", bes[0].UUID)
 	}
 
@@ -339,7 +339,7 @@ func TestPriorityExtra(t *testing.T) {
 		t.Fatalf("Invalid backend length [%v]", len(bes))
 	}
 
-	if bes[0].Host != "fooff" {
+	if bes[0].Host != ".fooff" {
 		t.Fatalf("Invalid order for the 1st element: [%v]", bes[0].UUID)
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/7145

so the refactored LB wildcards are treated the same way as "old style" haproxy:

https://github.com/alena1108/cattle/blob/haproxyreload/resources/content/config-content/haproxy/content/etc/haproxy/haproxy.cfg.ftl#L56