### PR TITLE
Attempting haproxy reload fix

### DIFF
--- a/package/haproxy/Dockerfile
+++ b/package/haproxy/Dockerfile
@@ -9,9 +9,8 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     rsyslog \
     wget \
+    haproxy \
     software-properties-common && \
-    add-apt-repository ppa:vbernat/haproxy-1.6 && \
-    apt-get update && apt-get install -y haproxy && \
     rm -rf /var/lib/apt/lists
 
 RUN mkdir -p /etc/haproxy/

--- a/provider/haproxy/scripts/haproxy_reload
+++ b/provider/haproxy/scripts/haproxy_reload
@@ -4,19 +4,19 @@ set -e
 reload_haproxy(){
     # start rsyslog if not running 
     if [[ $(pgrep rsyslog | wc -l) != 1 ]]; then
-        rm -f /var/run/rsyslogd.pid
+        rm -f /run/rsyslogd.pid
         rsyslogd -f /etc/haproxy/rsyslogd.conf > /dev/null
     fi
 
-    if [ ! -f /var/run/haproxy.pid ] || [ $2 == "start" ]; then
-        if haproxy -p /var/run/haproxy.pid -f $1; then
+    if [ ! -f /run/haproxy.pid ] || [ $2 == "start" ]; then
+        if service haproxy start; then
             return 0
         else
             return 1
         fi
     fi
-    # restart service
-    if haproxy -p /var/run/haproxy.pid -f $1 -sf $(cat /var/run/haproxy.pid); then
+    # reload service
+    if service haproxy reload; then
         return 0
     else
         return 1


### PR DESCRIPTION
Hi Alena,
In your commit 64c0f1c46140d99b2371f9d6a013170598128b33 you switched to the Ubuntu 16.04 image. Xenial already includes HAProxy 1.6, so is there a reason why to still use the PPA?
The haproxy init scripts from the official Ubuntu Xenial repos work correctly (reload, restart, start correctly tested). I see no reason why to try to not use the "service" command.
Furthermore, the current stop method using the "sf" parameter didn't work (tested inside a Rancher Load Balancer container on the shell). This could be the cause of having the load balancers stuck in the Initializing state, I'm not sure though.
Please give this pull request a shot or consider to use the offficial Ubuntu package and init scripts.