### PR TITLE
Fixes to skip incomplete cert. Instead of erroring out, we just log and proceed with the poll

### DIFF
--- a/controller/rancher/rancher_cert_dir_test.go
+++ b/controller/rancher/rancher_cert_dir_test.go
@@ -87,6 +87,22 @@ func TestCheckCertDirUpdate(t *testing.T) {
 		t.Fatalf("Error building config %v", err)
 	}
 
+	if len(newConfigs[0].Certs) != 3 {
+		t.Fatalf("Failed to read the Updated certificates from the directory")
+	}
+
+	err = ioutil.WriteFile("./testcerts/certs/c.com/privkey.pem", d1, 0644)
+	if err != nil {
+		t.Fatalf("Error writing file %v", err)
+	}
+
+	time.Sleep(10 * time.Second)
+
+	newConfigs, err2 = testlbc.BuildConfigFromMetadata("test", "", "", "any", nil)
+	if err2 != nil {
+		t.Fatalf("Error building config %v", err)
+	}
+
 	if len(newConfigs[0].Certs) != 4 {
 		t.Fatalf("Failed to read the Updated certificates from the directory")
 	}

--- a/controller/rancher/testcerts/certs/a.com/privkey.pem
+++ b/controller/rancher/testcerts/certs/a.com/privkey.pem
@@ -1,0 +1,1 @@
+privkey-1234.pem

--- a/controller/rancher/testcerts/certs/b.com/privkey.pem
+++ b/controller/rancher/testcerts/certs/b.com/privkey.pem
@@ -1,0 +1,1 @@
+privkey-8989.pem

--- a/controller/rancher/testcerts/defaultCert/default.com/privkey.pem
+++ b/controller/rancher/testcerts/defaultCert/default.com/privkey.pem
@@ -1,0 +1,1 @@
+privkey-8000.pem


### PR DESCRIPTION
Fixes to skip incomplete cert instead of erroring out we just log error, this will allow the poll to proceed and read and apply other certs to haproxy config successfully

Also only when both the fullchain.pem and privkey.pem files are found then the cert is added to the list.

https://github.com/rancher/rancher/issues/8366
https://github.com/rancher/rancher/issues/8401