### PR TITLE
Custom haproxy config fix: Exclude backend configs for targets that do not exist

### DIFF
--- a/provider/haproxy/haproxy_config_util.go
+++ b/provider/haproxy/haproxy_config_util.go
@@ -94,6 +94,7 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 	customConfigMap := make(map[string][]string)
 	var key string
 	defaultConfig := GetDefaultConfig()
+
 	serverPrefix := "server $IP"
 	for _, conf := range strings.Split(customConfig, "\n") {
 		trimmedConf := strings.TrimSpace(conf)
@@ -238,6 +239,9 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 			continue
 		}
 		if _, ok := processedConfigs[k]; !ok {
+			if strings.HasPrefix(k, "backend") && strings.HasSuffix(k, "_$IP") {
+				continue
+			}
 			extraConfig = fmt.Sprintf("%s\n%s\n", k, confToString(v, false, true))
 		}
 	}

--- a/provider/haproxy/test_data/custom_config_backend_server
+++ b/provider/haproxy/test_data/custom_config_backend_server
@@ -6,3 +6,6 @@ backend foo
 backend foofoo
     description my backend foofoo
     grace 90
+
+backend backend1
+	server $IP check


### PR DESCRIPTION
Do not include the backends in the custom config, if they are not found in the loadbalancer backends.

This happens if some target services are stopped, the config related to these
stopped targets should not be added to haproxy config even if they are mentioned in custom config, else they cause haproxy reoad to fail.

Updated existing config test, to make sure config related to non-existing backends are excluded in the final config.

https://github.com/rancher/rancher/issues/8424