### PR TITLE
Allow more than one extra section in haproxy config

### DIFF
--- a/provider/haproxy/haproxy_config_util.go
+++ b/provider/haproxy/haproxy_config_util.go
@@ -234,7 +234,14 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 
 	// append non-processed config
 	var extraConfig string
-	for k, v := range customConfigMap {
+	customConfigMapKeys := []string{}
+	for k := range customConfigMap {
+		customConfigMapKeys = append(customConfigMapKeys, k)
+	}
+	sort.Strings(customConfigMapKeys)
+	for _, k := range customConfigMapKeys {
+		v := customConfigMap[k]
+
 		if strings.EqualFold(k, "global") || strings.EqualFold(k, "backend") || strings.EqualFold(k, "defaults") {
 			continue
 		}
@@ -242,7 +249,7 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 			if strings.HasPrefix(k, "backend") && strings.HasSuffix(k, "_$IP") {
 				continue
 			}
-			extraConfig = fmt.Sprintf("%s\n%s\n", k, confToString(v, false, true))
+			extraConfig = fmt.Sprintf("%s%s\n%s\n", extraConfig, k, confToString(v, false, true))
 		}
 	}
 

--- a/provider/haproxy/haproxy_test.go
+++ b/provider/haproxy/haproxy_test.go
@@ -168,6 +168,54 @@ func TestBuildCustomConfigExtraFrontend(t *testing.T) {
 	}
 }
 
+func TestBuildCustomConfigMultipleExtra(t *testing.T) {
+	customConfig, err := getCustomConfig("custom_config_multiple_extra")
+	if err != nil {
+		t.Fatalf("Failed to read custom config: %v", err)
+	}
+	backends := []*config.BackendService{}
+	var eps config.Endpoints
+	ep := &config.Endpoint{
+		Name: "s1",
+		IP:   "10.1.1.1",
+		Port: 90,
+	}
+	eps = append(eps, ep)
+	backend := &config.BackendService{
+		UUID:      "bar",
+		Port:      8080,
+		Protocol:  config.HTTPProto,
+		Endpoints: eps,
+	}
+	backends = append(backends, backend)
+	frontend := &config.FrontendService{
+		Name:            "foo",
+		Port:            80,
+		Protocol:        config.HTTPProto,
+		BackendServices: backends,
+	}
+
+	frontends := []*config.FrontendService{}
+	frontends = append(frontends, frontend)
+
+	lbConfig := &config.LoadBalancerConfig{
+		FrontendServices: frontends,
+	}
+	err = lbp.ProcessCustomConfig(lbConfig, customConfig)
+	if err != nil {
+		t.Fatalf("Error while process custom config: %v", err)
+	}
+
+	result, err := validateCustomConfig("custom_config_multiple_extra_resp", lbConfig.Config)
+	if err != nil {
+		t.Fatalf("Error validating custom config: %v", err)
+	}
+
+	if !result {
+		t.Fatal("Configs don't match")
+	}
+}
+
 func TestBuildCustomConfigBackendSection(t *testing.T) {
 	customConfig, err := getCustomConfig("custom_config_frontend_backend")
 	if err != nil {

--- a/provider/haproxy/test_data/custom_config_multiple_extra
+++ b/provider/haproxy/test_data/custom_config_multiple_extra
@@ -6,7 +6,8 @@ frontend 80
   mode http
   redirect scheme https code 301 if !{ ssl_fc }
 
-listen stats :9000
+listen stats
+  bind *:9000
   mode http
   stats enable
   stats hide-version

--- a/provider/haproxy/test_data/custom_config_multiple_extra
+++ b/provider/haproxy/test_data/custom_config_multiple_extra
@@ -1,0 +1,19 @@
+defaults
+  log 127.0.0.1:8514 local0 debug
+
+frontend 80
+  bind *:80
+  mode http
+  redirect scheme https code 301 if !{ ssl_fc }
+
+listen stats :9000
+  mode http
+  stats enable
+  stats hide-version
+  stats realm Haproxy\ Statistics
+  stats uri /haproxy_stats
+
+frontend 81
+  bind *:81
+  mode http
+  redirect scheme https code 301 if !{ ssl_fc }

--- a/provider/haproxy/test_data/custom_config_multiple_extra_resp
+++ b/provider/haproxy/test_data/custom_config_multiple_extra_resp
@@ -37,7 +37,8 @@ frontend 81
       bind *:81
       mode http
       redirect scheme https code 301 if !{ ssl_fc }
-listen stats :9000
+listen stats
+      bind *:9000
       mode http
       stats enable
       stats hide-version

--- a/provider/haproxy/test_data/custom_config_multiple_extra_resp
+++ b/provider/haproxy/test_data/custom_config_multiple_extra_resp
@@ -1,0 +1,45 @@
+global
+    chroot /var/lib/haproxy
+    daemon
+    group haproxy
+    maxconn 4096
+    maxpipes 1024
+    ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
+    ssl-default-bind-options no-sslv3 no-tlsv10
+    ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
+    tune.ssl.default-dh-param 2048
+    user haproxy
+
+defaults
+      log 127.0.0.1:8514 local0 debug
+    errorfile 400 /etc/haproxy/errors/400.http
+    errorfile 403 /etc/haproxy/errors/403.http
+    errorfile 408 /etc/haproxy/errors/408.http
+    errorfile 500 /etc/haproxy/errors/500.http
+    errorfile 502 /etc/haproxy/errors/502.http
+    errorfile 503 /etc/haproxy/errors/503.http
+    errorfile 504 /etc/haproxy/errors/504.http
+    maxconn 4096
+    mode tcp
+    option forwardfor
+    option http-server-close
+    option redispatch
+    retries 3
+    timeout client 50000
+    timeout connect 5000
+    timeout server 50000
+
+frontend 80
+      bind *:80
+      mode http
+      redirect scheme https code 301 if !{ ssl_fc }
+frontend 81
+      bind *:81
+      mode http
+      redirect scheme https code 301 if !{ ssl_fc }
+listen stats :9000
+      mode http
+      stats enable
+      stats hide-version
+      stats realm Haproxy\ Statistics
+      stats uri /haproxy_stats


### PR DESCRIPTION
If given more than one extra section only one of these gets to be in the final config. 
I've modified the extra config generation section to allow more than one of these appended at the end sorted by section tag.