### PR TITLE
Modified rsyslogd.conf to remove parsing errors

### DIFF
--- a/provider/haproxy/config/rsyslogd.conf
+++ b/provider/haproxy/config/rsyslogd.conf
@@ -4,15 +4,14 @@ $template CustomFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg%\n"
 $ActionFileDefaultTemplate CustomFormat
 
 /* info */
-if $programname contains 'haproxy' and $syslogseverity == 6 then (
+if $programname contains 'haproxy' and $syslogseverity == 6 then
     action(type="omfile" file="/var/log/haproxy/traffic")
-)
-if $programname contains 'haproxy' and $syslogseverity-text == 'err' then (
+
+if $programname contains 'haproxy' and $syslogseverity-text == 'err' then
     action(type="omfile" file="/var/log/haproxy/errors")
-)
+
 /* notice */
-if $programname contains 'haproxy' and $syslogseverity <= 5 then (
+if $programname contains 'haproxy' and $syslogseverity <= 5 then
     action(type="omfile" file="/var/log/haproxy/events")
-)
 
 *.* /var/log/messages


### PR DESCRIPTION
[rancher/rancher#7591](https://github.com/rancher/rancher/issues/7591)

For rsyslog to start logging information to /var/logs/haproxy, use in the lb custom config file. 
```
defaults
log 127.0.0.1:8514 local0 debug
```

Note - With or without logging, other general information will appear in /var/logs/messages like - 
```
Jul 14 19:17:59 ab6118b225bb rsyslogd: [origin software="rsyslogd" swVersion="8.16.0" x-pid="22" x-info="http://www.rsyslog.com"] start
```

Tested on:
rancher/server:v1.6.3
rancher/lb-service-haproxy:v0.7.5 