### PR TITLE
showing haproxy logs in stdout and stderr

### DIFF
--- a/package/haproxy/Dockerfile
+++ b/package/haproxy/Dockerfile
@@ -33,6 +33,10 @@ RUN wget -O /usr/bin/update-rancher-ssl https://raw.githubusercontent.com/ranche
 
 COPY lb-controller.sh /usr/bin/
 
+RUN ln -sf /proc/1/fd/1 /var/log/haproxy/events
+RUN ln -sf /proc/1/fd/1 /var/log/haproxy/traffic
+RUN ln -sf /proc/1/fd/2 /var/log/haproxy/errors
+
 # So we do not write to the COW filesystem
 VOLUME /var/log/haproxy
 

--- a/provider/haproxy/config/rsyslogd.conf
+++ b/provider/haproxy/config/rsyslogd.conf
@@ -3,15 +3,12 @@ $UDPServerRun 8514
 $template CustomFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg%\n"
 $ActionFileDefaultTemplate CustomFormat
 
-/* info */
-if $programname contains 'haproxy' and $syslogseverity == 6 then
-    action(type="omfile" file="/var/log/haproxy/traffic")
-
-if $programname contains 'haproxy' and $syslogseverity-text == 'err' then
-    action(type="omfile" file="/var/log/haproxy/errors")
-
-/* notice */
-if $programname contains 'haproxy' and $syslogseverity <= 5 then
-    action(type="omfile" file="/var/log/haproxy/events")
-
-*.* /var/log/messages
+if $programname contains 'haproxy' then {
+  if $syslogseverity == 6 then
+      action(type="omfile" file="/var/log/haproxy/traffic")
+  if $syslogseverity-text == 'err' then
+      action(type="omfile" file="/var/log/haproxy/errors")
+  if $syslogseverity <= 5 then
+      action(type="omfile" file="/var/log/haproxy/events")
+} else
+  action(type="omfile" file="/var/log/messages")


### PR DESCRIPTION
[rancher/rancher#6504](https://github.com/rancher/rancher/issues/6504)

To test,
1. Enable logging by adding this in custom haproxy.cfg - 
`defaults
log 127.0.0.1:8514 local0 debug
`
2. Hit load balancer. View Logs. 
Observe events and traffic getting logged in Standard Out. Errors in Standard Error. 

To look out for only haproxy related logs, check /var/log/haproxy/errors|events|traffic. 