### PR TITLE
Code to read the k8s livenessProbes label and add healtchecks for haproxy backends

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -25,6 +27,10 @@ const (
 	BegRuleComparator = "beg"
 	EndRuleComparator = "end"
 )
+
+const backendPattern = `[^A-Za-z0-9]+`
+
+var regexBackend = regexp.MustCompile(backendPattern)
 
 type HealthCheck struct {
 	ResponseTimeout    int    `json:"response_timeout"`
@@ -166,4 +172,13 @@ func (s Endpoints) Swap(i, j int) {
 }
 func (s Endpoints) Less(i, j int) bool {
 	return strings.Compare(s[i].IP, s[j].IP) > 0
+}
+
+func FormulateBackendName(sourcePort int64, hostname string, path string) string {
+	var bName string
+
+	pathUUID := fmt.Sprintf("%v_%s_%s", sourcePort, hostname, path)
+	bName = regexBackend.ReplaceAllString(pathUUID, "_")
+
+	return bName
 }

--- a/controller/rancher/rancher.go
+++ b/controller/rancher/rancher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rancher/lb-controller/provider"
 	utils "github.com/rancher/lb-controller/utils"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -281,10 +280,7 @@ func (lbc *LoadBalancerController) BuildConfigFromMetadata(lbName, envUUID, self
 
 	allBe := make(map[string]*config.BackendService)
 	allEps := make(map[string]map[string]string)
-	reg, err := regexp.Compile("[^A-Za-z0-9]+")
-	if err != nil {
-		return nil, err
-	}
+
 	for _, rule := range lbMeta.PortRules {
 		if rule.SourcePort < 1 {
 			continue
@@ -372,7 +368,7 @@ func (lbc *LoadBalancerController) BuildConfigFromMetadata(lbName, envUUID, self
 			UUID := rule.BackendName
 			if UUID == "" {
 				//replace all non alphanumeric with _
-				UUID = reg.ReplaceAllString(pathUUID, "_")
+				UUID = config.FormulateBackendName(int64(rule.SourcePort), hostname, path)
 			}
 			backend := &config.BackendService{
 				UUID:           UUID,


### PR DESCRIPTION
This commit looks for a label 'io.rancher.kubernetes.livenessprobes' in the ingress annotations field and configures haproxy healthchecks for the backends by creating a custom config.

The format of the 'io.rancher.kubernetes.livenessprobes' value should provide details of healthcheck using k8s http or tcp livenessprobes fields: 

- k8s http liveness probe: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request

- k8s tcp liveness probe: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-tcp-liveness-probe

Example: 

- To add http healthcheck to haproxy backend: 

io.rancher.kubernetes.livenessprobes: "{\"<service_name>\": {\"httpGet\": {\"path\": \"<path>\", \"port\": <service_port>},\"periodSeconds\": 3, \"timeoutSeconds\": 4, \"successThreshold\": 2, \"failureThreshold\": 3}}"

- To add tcp healthcheck to haproxy backend: 

io.rancher.kubernetes.livenessprobes: "{\"<service_name>\": {\"tcpSocket\": {\"port\": <port_for_tcp_check>},\"periodSeconds\": 3, \"timeoutSeconds\": 3, \"successThreshold\": 1, \"failureThreshold\": 2}}"

- Multiple probes can also be defined for multiple services of the ingress spec

io.rancher.kubernetes.livenessprobes: "{\"<service_1_name>\": {\"httpGet\": {\"path\": \"<path>\", \"port\": <service_port>},\"periodSeconds\": 3, \"timeoutSeconds\": 4, \"successThreshold\": 2, \"failureThreshold\": 3}, \"<service_2_name>\": {\"tcpSocket\": {\"port\": <port_for_tcp_check>},\"periodSeconds\": 3, \"timeoutSeconds\": 3, \"successThreshold\": 1, \"failureThreshold\": 2}}"

https://github.com/rancher/rancher/issues/10102

@alena1108 pls. review