### PR TITLE
Preserve the order of the services in the livenessProbes label by sorting

### DIFF
--- a/controller/kubernetes/kubernetes.go
+++ b/controller/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -580,11 +581,17 @@ func (lbc *loadBalancerController) getProbeConfig(probeStr string, frontEndServi
 		if svcBackendNameMap == nil {
 			return "", fmt.Errorf("Error creating the service to backend names map")
 		}
+		var probeServicekeys []string
+		for service := range livenessProbeMap {
+			probeServicekeys = append(probeServicekeys, service)
+		}
+		sort.Strings(probeServicekeys)
 
-		for service, probeStruct := range livenessProbeMap {
+		for _, service := range probeServicekeys {
 			if _, ok := svcBackendNameMap[service]; !ok {
 				return "", fmt.Errorf("Ingress spec seems to be missing backend service: %v from the livenessProbes %v", service, probeStr)
 			}
+			probeStruct := livenessProbeMap[service]
 			subConfig := "backend " + svcBackendNameMap[service]
 			port := 0
 


### PR DESCRIPTION
Since iteration order on golang maps is random, we were generating the custom config with different order of services everytime, causing an update of the ingress services even though the config is not really different.

Now sort the servicenames to preserve the order in the custom config.

https://github.com/rancher/rancher/issues/10345

@alena1108 pls. review