### PR TITLE
HAProxy loadbalancer generates invalid health check on upgrade #8538

### DIFF
--- a/provider/haproxy/haproxy_config_util.go
+++ b/provider/haproxy/haproxy_config_util.go
@@ -212,19 +212,19 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 
 				if healthcheck {
 					// taken from rancher/healthcheck default behaviour
-					fall:=""
-					if(be.HealthCheck.UnhealthyThreshold !=  0){
-						fall=fmt.Sprintf(" fall %v", be.HealthCheck.UnhealthyThreshold)
+					fall := ""
+					if be.HealthCheck.UnhealthyThreshold > 0 {
+						fall = fmt.Sprintf(" fall %v", be.HealthCheck.UnhealthyThreshold)
 					}
 
-					rise:=""
-					if(be.HealthCheck.HealthyThreshold != 0) {
-						rise=fmt.Sprintf(" rise %v",be.HealthCheck.HealthyThreshold)
+					rise := ""
+					if be.HealthCheck.HealthyThreshold > 0 {
+						rise = fmt.Sprintf(" rise %v", be.HealthCheck.HealthyThreshold)
 					}
 
-					inter:=""
-					if(be.HealthCheck.Interval != 0) {
-						inter=fmt.Sprintf(" inter %v", be.HealthCheck.Interval)
+					inter := ""
+					if be.HealthCheck.Interval > 0 {
+						inter = fmt.Sprintf(" inter %v", be.HealthCheck.Interval)
 					}
 
 					hc := fmt.Sprintf("check port %v%s%s%s", be.HealthCheck.Port, inter, rise, fall)

--- a/provider/haproxy/haproxy_config_util.go
+++ b/provider/haproxy/haproxy_config_util.go
@@ -211,7 +211,23 @@ func BuildCustomConfig(lbConfig *config.LoadBalancerConfig, customConfig string)
 				//append health check
 
 				if healthcheck {
-					hc := fmt.Sprintf("check port %v inter %v rise %v fall %v", be.HealthCheck.Port, be.HealthCheck.Interval, be.HealthCheck.HealthyThreshold, be.HealthCheck.UnhealthyThreshold)
+					// taken from rancher/healthcheck default behaviour
+					fall:=""
+					if(be.HealthCheck.UnhealthyThreshold !=  0){
+						fall=fmt.Sprintf(" fall %v", be.HealthCheck.UnhealthyThreshold)
+					}
+
+					rise:=""
+					if(be.HealthCheck.HealthyThreshold != 0) {
+						rise=fmt.Sprintf(" rise %v",be.HealthCheck.HealthyThreshold)
+					}
+
+					inter:=""
+					if(be.HealthCheck.Interval != 0) {
+						inter=fmt.Sprintf(" inter %v", be.HealthCheck.Interval)
+					}
+
+					hc := fmt.Sprintf("check port %v%s%s%s", be.HealthCheck.Port, inter, rise, fall)
 					ep.Config = fmt.Sprintf("%s %s", ep.Config, hc)
 				}
 				if ep.IsCname {


### PR DESCRIPTION
original issue
https://github.com/rancher/rancher/issues/8538

root cause:
unhealthy_threshold, healthy_threshold were not defined in rancher-compose

healthcheck itself was working fine because it used haproxy defaults and i am simply copying this behaviour to lb-haproxy

look for unhealthythreshold
https://github.com/rancher/healthcheck/blob/88f094fd9d7c0a29d6d63179d83f3c8ffeae2322/pkg/haproxy/haproxy_config.go
