### PR TITLE
LB selector based port rules will skip the hostname/path based routing rule if label is set and the selector target service is an LB service

### DIFF
--- a/controller/rancher/rancher_regions_test.go
+++ b/controller/rancher/rancher_regions_test.go
@@ -61,7 +61,7 @@ func TestSelectorMatch1(t *testing.T) {
 		PortRules: portRules,
 	}
 
-	lbc1.processSelector(meta)
+	lbc1.processSelector(meta, false)
 
 	configs, _ := lbc1.BuildConfigFromMetadata("test", "", "", "any", meta)
 

--- a/controller/rancher/rancher_test.go
+++ b/controller/rancher/rancher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/rancher/go-rancher-metadata/metadata"
 	"github.com/rancher/go-rancher/v2"
 	"github.com/rancher/lb-controller/config"
@@ -839,7 +840,7 @@ func TestSelectorNoMatch(t *testing.T) {
 		PortRules: portRules,
 	}
 
-	lbc.processSelector(meta)
+	lbc.processSelector(meta, false)
 
 	configs, _ := lbc.BuildConfigFromMetadata("test", "", "", "any", meta)
 
@@ -860,7 +861,7 @@ func TestSelectorMatch(t *testing.T) {
 		PortRules: portRules,
 	}
 
-	lbc.processSelector(meta)
+	lbc.processSelector(meta, false)
 
 	configs, _ := lbc.BuildConfigFromMetadata("test", "", "", "any", meta)
 
@@ -911,7 +912,7 @@ func TestSelectorMatchNoTargetPort(t *testing.T) {
 		PortRules: portRules,
 	}
 
-	lbc.processSelector(meta)
+	lbc.processSelector(meta, false)
 
 	configs, _ := lbc.BuildConfigFromMetadata("test", "", "", "any", meta)
 


### PR DESCRIPTION
For selector based rules, Skip adding hostname/path routing rules if label 'io.rancher.lb_service.skip_target_lb_rules' is set to "true" on the LB and the target service is of kind Loadbalancerservice


https://github.com/rancher/rancher/issues/17974