### PR TITLE
update haproxy to the last 2.0.9

### DIFF
--- a/package/haproxy/Dockerfile
+++ b/package/haproxy/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     rsyslog \
     wget \
-    haproxy \
+    haproxy=2.0.9-1ppa1~xenial \
     software-properties-common && \
     rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
There is a regression with haproxy 2.0.5
if you choose the last haproxy=2.0.9-1ppa1~xenial  in dockerfile, the regression is solved

please see https://github.com/rancher/rancher/issues/23787